### PR TITLE
fixes #1: added sample files under data/ and made them defaults

### DIFF
--- a/data/sample_expenses_1995.csv
+++ b/data/sample_expenses_1995.csv
@@ -1,0 +1,22 @@
+Date,Account Name,Number,Description,Notes,Memo,Category,Type,Action,Reconcile,To With Sym,From With Sym,To Num.,From Num.,To Rate/Price,From Rate/Price
+12/27/1995,M,113,AAA,,,New Bank,T,,N,$39.00,,39.00,,,
+,,,,,,M,S,,N,$39.00,,39.00,,1.00,
+,,,,,,New Bank,S,,N,,-$39.00,,-39.00,,1.00
+12/31/1995,Natural Gas,115,Gas Co.,,,New Bank,T,,N,$78.04,,78.04,,,
+,,,,,,Natural Gas,S,,N,$78.04,,78.04,,1.00,
+,,,,,,New Bank,S,,N,,-$78.04,,-78.04,,1.00
+12/03/1995,Rent,106,Landlord,,,New Bank,T,,N,$525.00,,525.00,,,
+,,,,,,Rent,S,,N,$525.00,,525.00,,1.00,
+,,,,,,New Bank,S,,N,,-$525.00,,-525.00,,1.00
+12/08/1995,Telephone,108,Pacific Bell,,,New Bank,T,,N,$56.83,,56.83,,,
+,,,,,,Telephone,S,,N,$56.83,,56.83,,1.00,
+,,,,,,New Bank,S,,N,,-$56.83,,-56.83,,1.00
+12/27/1995,Groceries,111,B's Supermarket,,,New Bank,T,,N,$9.89,,9.89,,,
+,,,,,,Groceries,S,,N,$9.89,,9.89,,1.00,
+,,,,,,New Bank,S,,N,,-$9.89,,-9.89,,1.00
+12/05/1995,Auto Insurance,107,Insurance,,,New Bank,T,,N,$539.60,,539.60,,,
+,,,,,,Auto Insurance,S,,N,$539.60,,539.60,,1.00,
+,,,,,,New Bank,S,,N,,-$539.60,,-539.60,,1.00
+12/27/1995,Clothing,112,Court,,,New Bank,T,,N,$86.00,,86.00,,,
+,,,,,,Clothing,S,,N,$86.00,,86.00,,1.00,
+,,,,,,New Bank,S,,N,,-$86.00,,-86.00,,1.00

--- a/data/sample_expenses_1996H1.csv
+++ b/data/sample_expenses_1996H1.csv
@@ -1,0 +1,97 @@
+Date,Account Name,Number,Description,Notes,Memo,Category,Type,Action,Reconcile,To With Sym,From With Sym,To Num.,From Num.,To Rate/Price,From Rate/Price
+02/03/1996,Bills,124,DBC,,,New Bank,T,,N,$24.89,,24.89,,,
+,,,,,,Bills,S,,N,$24.89,,24.89,,1.00,
+,,,,,,New Bank,S,,N,,-$24.89,,-24.89,,1.00
+02/07/1996,Electricity,,Power Co.,,,New Bank,T,,N,$46.53,,46.53,,,
+,,,,,,Electricity,S,,N,$46.53,,46.53,,1.00,
+,,,,,,New Bank,S,,N,,-$46.53,,-46.53,,1.00
+02/27/1996,Electricity,,Power Co.,,,New Bank,T,,N,$23.14,,23.14,,,
+,,,,,,Electricity,S,,N,$23.14,,23.14,,1.00,
+,,,,,,New Bank,S,,N,,-$23.14,,-23.14,,1.00
+04/08/1996,Electricity,,Power Co.,,,New Bank,T,,N,$19.28,,19.28,,,
+,,,,,,Electricity,S,,N,$19.28,,19.28,,1.00,
+,,,,,,New Bank,S,,N,,-$19.28,,-19.28,,1.00
+05/01/1996,Electricity,,Power Co.,,,New Bank,T,,N,$19.78,,19.78,,,
+,,,,,,Electricity,S,,N,$19.78,,19.78,,1.00,
+,,,,,,New Bank,S,,N,,-$19.78,,-19.78,,1.00
+06/10/1996,Electricity,,Power Co.,,,New Bank,T,,N,$25.36,,25.36,,,
+,,,,,,Electricity,S,,N,$25.36,,25.36,,1.00,
+,,,,,,New Bank,S,,N,,-$25.36,,-25.36,,1.00
+01/28/1996,Natural Gas,123,Gas Co.,,,New Bank,T,,N,$55.95,,55.95,,,
+,,,,,,Natural Gas,S,,N,$55.95,,55.95,,1.00,
+,,,,,,New Bank,S,,N,,-$55.95,,-55.95,,1.00
+03/09/1996,Natural Gas,137,Gas Co.,,,New Bank,T,,N,$18.75,,18.75,,,
+,,,,,,Natural Gas,S,,N,$18.75,,18.75,,1.00,
+,,,,,,New Bank,S,,N,,-$18.75,,-18.75,,1.00
+04/10/1996,Natural Gas,145,Gas Co.,,,New Bank,T,,N,$23.09,,23.09,,,
+,,,,,,Natural Gas,S,,N,$23.09,,23.09,,1.00,
+,,,,,,New Bank,S,,N,,-$23.09,,-23.09,,1.00
+01/01/1996,Rent,116,Landlord,,,New Bank,T,,N,$525.00,,525.00,,,
+,,,,,,Rent,S,,N,$525.00,,525.00,,1.00,
+,,,,,,New Bank,S,,N,,-$525.00,,-525.00,,1.00
+02/01/1996,Rent,126,Landlord,,,New Bank,T,,N,$525.00,,525.00,,,
+,,,,,,Rent,S,,N,$525.00,,525.00,,1.00,
+,,,,,,New Bank,S,,N,,-$525.00,,-525.00,,1.00
+03/02/1996,Rent,135,Landlord,,,New Bank,T,,N,$525.00,,525.00,,,
+,,,,,,Rent,S,,N,$525.00,,525.00,,1.00,
+,,,,,,New Bank,S,,N,,-$525.00,,-525.00,,1.00
+04/01/1996,Rent,144,Landlord,,,New Bank,T,,N,$525.00,,525.00,,,
+,,,,,,Rent,S,,N,$525.00,,525.00,,1.00,
+,,,,,,New Bank,S,,N,,-$525.00,,-525.00,,1.00
+05/01/1996,Rent,149,Landlord,,,New Bank,T,,N,$525.00,,525.00,,,
+,,,,,,Rent,S,,N,$525.00,,525.00,,1.00,
+,,,,,,New Bank,S,,N,,-$525.00,,-525.00,,1.00
+06/02/1996,Rent,158,Landlord,,,New Bank,T,,N,$525.00,,525.00,,,
+,,,,,,Rent,S,,N,$525.00,,525.00,,1.00,
+,,,,,,New Bank,S,,N,,-$525.00,,-525.00,,1.00
+01/23/1996,Telephone,120,Pacific Bell,,,New Bank,T,,N,$95.31,,95.31,,,
+,,,,,,Telephone,S,,N,$95.31,,95.31,,1.00,
+,,,,,,New Bank,S,,N,,-$95.31,,-95.31,,1.00
+02/07/1996,Telephone,128,Pacific Bell,,,New Bank,T,,N,$50.61,,50.61,,,
+,,,,,,Telephone,S,,N,$50.61,,50.61,,1.00,
+,,,,,,New Bank,S,,N,,-$50.61,,-50.61,,1.00
+03/09/1996,Telephone,139,Pacific Bell,,,New Bank,T,,N,$49.51,,49.51,,,
+,,,,,,Telephone,S,,N,$49.51,,49.51,,1.00,
+,,,,,,New Bank,S,,N,,-$49.51,,-49.51,,1.00
+04/10/1996,Telephone,146,Pacific Bell,,,New Bank,T,,N,$22.74,,22.74,,,
+,,,,,,Telephone,S,,N,$22.74,,22.74,,1.00,
+,,,,,,New Bank,S,,N,,-$22.74,,-22.74,,1.00
+05/02/1996,Telephone,151,LDPC Co.,,,New Bank,T,,N,$41.70,,41.70,,,
+,,,,,,Telephone,S,,N,$41.70,,41.70,,1.00,
+,,,,,,New Bank,S,,N,,-$41.70,,-41.70,,1.00
+05/19/1996,Telephone,154,Pacific Bell,,,New Bank,T,,N,$56.07,,56.07,,,
+,,,,,,Telephone,S,,N,$56.07,,56.07,,1.00,
+,,,,,,New Bank,S,,N,,-$56.07,,-56.07,,1.00
+06/06/1996,Telephone,160,LDPC Co.,,,New Bank,T,,N,$42.72,,42.72,,,
+,,,,,,Telephone,S,,N,$42.72,,42.72,,1.00,
+,,,,,,New Bank,S,,N,,-$42.72,,-42.72,,1.00
+06/06/1996,Telephone,161,Pacific Bell,,,New Bank,T,,N,$48.25,,48.25,,,
+,,,,,,Telephone,S,,N,$48.25,,48.25,,1.00,
+,,,,,,New Bank,S,,N,,-$48.25,,-48.25,,1.00
+02/21/1996,Clothing,134,HCA,,,New Bank,T,,N,$3.98,,3.98,,,
+,,,,,,Clothing,S,,N,$3.98,,3.98,,1.00,
+,,,,,,New Bank,S,,N,,-$3.98,,-3.98,,1.00
+02/10/1996,Food,130,B's Supermarket,,,New Bank,T,,N,$2.40,,2.40,,,
+,,,,,,Food,S,,N,$2.40,,2.40,,1.00,
+,,,,,,New Bank,S,,N,,-$2.40,,-2.40,,1.00
+03/24/1996,Groceries,142,B's Supermarket,,,New Bank,T,,N,$10.10,,10.10,,,
+,,,,,,Groceries,S,,N,$10.10,,10.10,,1.00,
+,,,,,,New Bank,S,,N,,-$10.10,,-10.10,,1.00
+05/31/1996,Healthcare,157,Dr. Lin,,,New Bank,T,,N,$10.00,,10.00,,,
+,,,,,,Healthcare,S,,N,$10.00,,10.00,,1.00,
+,,,,,,New Bank,S,,N,,-$10.00,,-10.00,,1.00
+06/07/1996,Auto Insurance,162,Insurance Co.,,,New Bank,T,,N,$537.00,,537.00,,,
+,,,,,,Auto Insurance,S,,N,$537.00,,537.00,,1.00,
+,,,,,,New Bank,S,,N,,-$537.00,,-537.00,,1.00
+01/13/1996,Photo,117,MCL,,,New Bank,T,,N,$8.20,,8.20,,,
+,,,,,,Photo,S,,N,$8.20,,8.20,,1.00,
+,,,,,,New Bank,S,,N,,-$8.20,,-8.20,,1.00
+03/27/1996,Miscellaneous,,BB,,,New Bank,T,,N,-$154.31,,-154.31,,,
+,,,,,,New Bank,S,,N,,$154.31,,154.31,,1.00
+,,,,,,Miscellaneous,S,,N,-$154.31,,-154.31,,1.00,
+04/10/1996,Restaurants,,BB,,,New Bank,T,,N,$577.87,,577.87,,,
+,,,,,,Restaurants,S,,N,-$577.87,,577.87,,1.00,
+,,,,,,New Bank,S,,N,,$577.87,,-577.87,,1.00
+05/19/1996,Water,153,DW,,,New Bank,T,,N,$265.00,,265.00,,,
+,,,,,,Water,S,,N,$265.00,,265.00,,1.00,
+,,,,,,New Bank,S,,N,,-$265.00,,-265.00,,1.00

--- a/data/sample_expenses_1996H2.csv
+++ b/data/sample_expenses_1996H2.csv
@@ -1,0 +1,94 @@
+Date,Account Name,Number,Description,Notes,Memo,Category,Type,Action,Reconcile,To With Sym,From With Sym,To Num.,From Num.,To Rate/Price,From Rate/Price
+07/08/1996,Electricity,,Power Co.,,,New Bank,T,,N,$12.22,,12.22,,,
+,,,,,,Electricity,S,,N,$12.22,,12.22,,1.00,
+,,,,,,New Bank,S,,N,,-$12.22,,-12.22,,1.00
+08/06/1996,Electricity,,Power Co.,,,New Bank,T,,N,$20.40,,20.40,,,
+,,,,,,Electricity,S,,N,$20.40,,20.40,,1.00,
+,,,,,,New Bank,S,,N,,-$20.40,,-20.40,,1.00
+09/04/1996,Electricity,,Power Co.,,,New Bank,T,,N,$25.27,,25.27,,,
+,,,,,,Electricity,S,,N,$25.27,,25.27,,1.00,
+,,,,,,New Bank,S,,N,,-$25.27,,-25.27,,1.00
+10/04/1996,Electricity,,Power Co.,,,New Bank,T,,N,$16.69,,16.69,,,
+,,,,,,Electricity,S,,N,$16.69,,16.69,,1.00,
+,,,,,,New Bank,S,,N,,-$16.69,,-16.69,,1.00
+07/01/1996,Rent,167,Landlord,,,New Bank,T,,N,$525.00,,525.00,,,
+,,,,,,Rent,S,,N,$525.00,,525.00,,1.00,
+,,,,,,New Bank,S,,N,,-$525.00,,-525.00,,1.00
+08/01/1996,Rent,176,Landlord,,,New Bank,T,,N,$525.00,,525.00,,,
+,,,,,,Rent,S,,N,$525.00,,525.00,,1.00,
+,,,,,,New Bank,S,,N,,-$525.00,,-525.00,,1.00
+09/01/1996,Rent,181,Landlord,,,New Bank,T,,N,$525.00,,525.00,,,
+,,,,,,Rent,S,,N,$525.00,,525.00,,1.00,
+,,,,,,New Bank,S,,N,,-$525.00,,-525.00,,1.00
+10/01/1996,Rent,194,Landlord,,,New Bank,T,,N,$525.00,,525.00,,,
+,,,,,,Rent,S,,N,$525.00,,525.00,,1.00,
+,,,,,,New Bank,S,,N,,-$525.00,,-525.00,,1.00
+11/01/1996,Rent,202,Landlord,,,New Bank,T,,N,$525.00,,525.00,,,
+,,,,,,Rent,S,,N,$525.00,,525.00,,1.00,
+,,,,,,New Bank,S,,N,,-$525.00,,-525.00,,1.00
+12/03/1996,Rent,213,Landlord,,,New Bank,T,,N,$525.00,,525.00,,,
+,,,,,,Rent,S,,N,$525.00,,525.00,,1.00,
+,,,,,,New Bank,S,,N,,-$525.00,,-525.00,,1.00
+12/31/1996,Rent,223,Landlord,,,New Bank,T,,N,$525.00,,525.00,,,
+,,,,,,Rent,S,,N,$525.00,,525.00,,1.00,
+,,,,,,New Bank,S,,N,,-$525.00,,-525.00,,1.00
+07/16/1996,Telephone,170,Pacific Bell,,,New Bank,T,,N,$45.77,,45.77,,,
+,,,,,,Telephone,S,,N,$45.77,,45.77,,1.00,
+,,,,,,New Bank,S,,N,,-$45.77,,-45.77,,1.00
+08/08/1996,Telephone,177,Pacific Bell,,,New Bank,T,,N,$42.73,,42.73,,,
+,,,,,,Telephone,S,,N,$42.73,,42.73,,1.00,
+,,,,,,New Bank,S,,N,,-$42.73,,-42.73,,1.00
+09/01/1996,Telephone,184,LDPC Co.,,,New Bank,T,,N,$24.66,,24.66,,,
+,,,,,,Telephone,S,,N,$24.66,,24.66,,1.00,
+,,,,,,New Bank,S,,N,,-$24.66,,-24.66,,1.00
+09/16/1996,Telephone,190,Pacific Bell,,,New Bank,T,,N,$45.01,,45.01,,,
+,,,,,,Telephone,S,,N,$45.01,,45.01,,1.00,
+,,,,,,New Bank,S,,N,,-$45.01,,-45.01,,1.00
+10/07/1996,Telephone,195,Pacific Bell,,,New Bank,T,,N,$16.95,,16.95,,,
+,,,,,,Telephone,S,,N,$16.95,,16.95,,1.00,
+,,,,,,New Bank,S,,N,,-$16.95,,-16.95,,1.00
+10/07/1996,Telephone,196,Pacific Bell,,,New Bank,T,,N,$47.67,,47.67,,,
+,,,,,,Telephone,S,,N,$47.67,,47.67,,1.00,
+,,,,,,New Bank,S,,N,,-$47.67,,-47.67,,1.00
+10/07/1996,Telephone,197,LDPC,,,New Bank,T,,N,$65.39,,65.39,,,
+,,,,,,Telephone,S,,N,$65.39,,65.39,,1.00,
+,,,,,,New Bank,S,,N,,-$65.39,,-65.39,,1.00
+11/06/1996,Telephone,203,LDPC,,,New Bank,T,,N,$36.94,,36.94,,,
+,,,,,,Telephone,S,,N,$36.94,,36.94,,1.00,
+,,,,,,New Bank,S,,N,,-$36.94,,-36.94,,1.00
+11/06/1996,Telephone,204,Pacific Bell,,,New Bank,T,,N,$22.40,,22.40,,,
+,,,,,,Telephone,S,,N,$22.40,,22.40,,1.00,
+,,,,,,New Bank,S,,N,,-$22.40,,-22.40,,1.00
+11/12/1996,Telephone,205,Pacific Bell,,,New Bank,T,,N,$24.58,,24.58,,,
+,,,,,,Telephone,S,,N,$24.58,,24.58,,1.00,
+,,,,,,New Bank,S,,N,,-$24.58,,-24.58,,1.00
+12/07/1996,Telephone,216,Pacific Bell,,,New Bank,T,,N,$57.94,,57.94,,,
+,,,,,,Telephone,S,,N,$57.94,,57.94,,1.00,
+,,,,,,New Bank,S,,N,,-$57.94,,-57.94,,1.00
+12/10/1996,Telephone,219,Pacific Bell,,,New Bank,T,,N,$25.43,,25.43,,,
+,,,,,,Telephone,S,,N,$25.43,,25.43,,1.00,
+,,,,,,New Bank,S,,N,,-$25.43,,-25.43,,1.00
+07/16/1996,Education,171,Time,,,New Bank,T,,N,$29.97,,29.97,,,
+,,,,,,Education,S,,N,$29.97,,29.97,,1.00,
+,,,,,,New Bank,S,,N,,-$29.97,,-29.97,,1.00
+12/05/1996,Auto Insurance,214,Insurance,,,New Bank,T,,N,$424.00,,424.00,,,
+,,,,,,Auto Insurance,S,,N,$424.00,,424.00,,1.00,
+,,,,,,New Bank,S,,N,,-$424.00,,-424.00,,1.00
+11/18/1996,Leisure,209,LJ,,,New Bank,T,,N,$380.18,,380.18,,,
+,,,,,,Leisure,S,,N,$380.18,,380.18,,1.00,
+,,,,,,New Bank,S,,N,,-$380.18,,-380.18,,1.00
+11/25/1996,Booze,211,LJ,,,New Bank,T,,N,$51.00,,51.00,,,
+,,,,,,Booze,S,,N,$51.00,,51.00,,1.00,
+,,,,,,New Bank,S,,N,,-$51.00,,-51.00,,1.00
+09/23/1996,Student account,191,School,,,New Bank,T,,N,$127.52,,127.52,,,
+,,,,,,Student account,S,,N,$127.52,,127.52,,1.00,
+,,,,,,New Bank,S,,N,,-$127.52,,-127.52,,1.00
+07/16/1996,Water,174,City,,,New Bank,T,,N,$44.00,,44.00,,,
+,,,,,,Water,S,,N,$44.00,,44.00,,1.00,
+,,,,,,New Bank,S,,N,,-$44.00,,-44.00,,1.00
+07/16/1996,Water,175,City,,,New Bank,T,,N,$28.00,,28.00,,,
+,,,,,,Water,S,,N,$28.00,,28.00,,1.00,
+,,,,,,New Bank,S,,N,,-$28.00,,-28.00,,1.00
+09/01/1996,Water,183,City,,,New Bank,T,,N,$22.00,,22.00,,,
+,,,,,,Water,S,,N,$22.00,,22.00,,1.00,
+,,,,,,New Bank,S,,N,,-$22.00,,-22.00,,1.00

--- a/data/sample_expenses_1997_ytd.csv
+++ b/data/sample_expenses_1997_ytd.csv
@@ -1,0 +1,76 @@
+Date,Account Name,Number,Description,Notes,Memo,Category,Type,Action,Reconcile,To With Sym,From With Sym,To Num.,From Num.,To Rate/Price,From Rate/Price
+03/14/1997,Groceries,260,FTB,,,New Bank,T,,N,$89.87,,89.87,,,
+,,,,,,Groceries,S,,N,$89.87,,89.87,,1.00,
+,,,,,,New Bank,S,,N,,-$89.87,,-89.87,,1.00
+01/04/1997,Booze,224,Mellon Bank,,,New Bank,T,,N,$40.00,,40.00,,,
+,,,,,,Booze,S,,N,$40.00,,40.00,,1.00,
+,,,,,,New Bank,S,,N,,-$40.00,,-40.00,,1.00
+02/11/1997,Restaurants,239,CAF,,,New Bank,T,,N,$300.00,,300.00,,,
+,,,,,,Restaurants,S,,N,$300.00,,300.00,,1.00,
+,,,,,,New Bank,S,,N,,-$300.00,,-300.00,,1.00
+02/12/1997,Bank Charges,,Cash,,,New Bank,T,,N,$1.50,,1.50,,,
+,,,,,,Bank Charges,S,,N,$1.50,,1.50,,1.00,
+,,,,,,New Bank,S,,N,,-$1.50,,-1.50,,1.00
+03/04/1997,Bank Charges,,Coast Federal Bank,,,New Bank,T,,N,$2.00,,2.00,,,
+,,,,,,Bank Charges,S,,N,$2.00,,2.00,,1.00,
+,,,,,,New Bank,S,,N,,-$2.00,,-2.00,,1.00
+01/07/1997,Electricity,,Power Co.,,,New Bank,T,,N,$11.58,,11.58,,,
+,,,,,,Electricity,S,,N,$11.58,,11.58,,1.00,
+,,,,,,New Bank,S,,N,,-$11.58,,-11.58,,1.00
+02/07/1997,Electricity,,Power Co.,,,New Bank,T,,N,$21.43,,21.43,,,
+,,,,,,Electricity,S,,N,$21.43,,21.43,,1.00,
+,,,,,,New Bank,S,,N,,-$21.43,,-21.43,,1.00
+03/14/1997,Electricity,,Power Co.,,,New Bank,T,,N,$20.62,,20.62,,,
+,,,,,,Electricity,S,,N,$20.62,,20.62,,1.00,
+,,,,,,New Bank,S,,N,,-$20.62,,-20.62,,1.00
+01/31/1997,Rent,234,Landlord,,,New Bank,T,,N,$525.00,,525.00,,,
+,,,,,,Rent,S,,N,$525.00,,525.00,,1.00,
+,,,,,,New Bank,S,,N,,-$525.00,,-525.00,,1.00
+03/02/1997,Rent,250,Landlord,,,New Bank,T,,N,$525.00,,525.00,,,
+,,,,,,Rent,S,,N,$525.00,,525.00,,1.00,
+,,,,,,New Bank,S,,N,,-$525.00,,-525.00,,1.00
+03/31/1997,Rent,264,Landlord,,,New Bank,T,,N,$525.00,,525.00,,,
+,,,,,,Rent,S,,N,$525.00,,525.00,,1.00,
+,,,,,,New Bank,S,,N,,-$525.00,,-525.00,,1.00
+01/04/1997,Telephone,225,LDPC,,,New Bank,T,,N,$112.24,,112.24,,,
+,,,,,,Telephone,S,,N,$112.24,,112.24,,1.00,
+,,,,,,New Bank,S,,N,,-$112.24,,-112.24,,1.00
+01/10/1997,Telephone,227,Pacific Bell,,,New Bank,T,,N,$17.07,,17.07,,,
+,,,,,,Telephone,S,,N,$17.07,,17.07,,1.00,
+,,,,,,New Bank,S,,N,,-$17.07,,-17.07,,1.00
+01/10/1997,Telephone,228,Pacific Bell,,,New Bank,T,,N,$16.26,,16.26,,,
+,,,,,,Telephone,S,,N,$16.26,,16.26,,1.00,
+,,,,,,New Bank,S,,N,,-$16.26,,-16.26,,1.00
+02/06/1997,Telephone,235,LDPC,,,New Bank,T,,N,$3.35,,3.35,,,
+,,,,,,Telephone,S,,N,$3.35,,3.35,,1.00,
+,,,,,,New Bank,S,,N,,-$3.35,,-3.35,,1.00
+02/19/1997,Telephone,241,Pacific Bell,,,New Bank,T,,N,$16.10,,16.10,,,
+,,,,,,Telephone,S,,N,$16.10,,16.10,,1.00,
+,,,,,,New Bank,S,,N,,-$16.10,,-16.10,,1.00
+03/14/1997,Telephone,255,LDPC,,,New Bank,T,,N,$13.87,,13.87,,,
+,,,,,,Telephone,S,,N,$13.87,,13.87,,1.00,
+,,,,,,New Bank,S,,N,,-$13.87,,-13.87,,1.00
+03/14/1997,Telephone,256,Pacific Bell,,,New Bank,T,,N,$16.45,,16.45,,,
+,,,,,,Telephone,S,,N,$16.45,,16.45,,1.00,
+,,,,,,New Bank,S,,N,,-$16.45,,-16.45,,1.00
+03/14/1997,Telephone,259,Pacific Bell,,,New Bank,T,,N,$108.56,,108.56,,,
+,,,,,,Telephone,S,,N,$108.56,,108.56,,1.00,
+,,,,,,New Bank,S,,N,,-$108.56,,-108.56,,1.00
+03/31/1997,Telephone,263,LDPC,,,New Bank,T,,N,$4.80,,4.80,,,
+,,,,,,Telephone,S,,N,$4.80,,4.80,,1.00,
+,,,,,,New Bank,S,,N,,-$4.80,,-4.80,,1.00
+02/19/1997,Clothing,246,HCA,,,New Bank,T,,N,$4.48,,4.48,,,
+,,,,,,Clothing,S,,N,$4.48,,4.48,,1.00,
+,,,,,,New Bank,S,,N,,-$4.48,,-4.48,,1.00
+03/14/1997,Clothing,253,HCA,,,New Bank,T,,N,$12.27,,12.27,,,
+,,,,,,Clothing,S,,N,$12.27,,12.27,,1.00,
+,,,,,,New Bank,S,,N,,-$12.27,,-12.27,,1.00
+03/18/1997,Healthcare,261,Dr,,,New Bank,T,,N,$40.00,,40.00,,,
+,,,,,,Healthcare,S,,N,$40.00,,40.00,,1.00,
+,,,,,,New Bank,S,,N,,-$40.00,,-40.00,,1.00
+01/13/1997,Water,231,DWV,,,New Bank,T,,N,$12.00,,12.00,,,
+,,,,,,Water,S,,N,$12.00,,12.00,,1.00,
+,,,,,,New Bank,S,,N,,-$12.00,,-12.00,,1.00
+02/11/1997,Water,240,City,,,New Bank,T,,N,$50.00,,50.00,,,
+,,,,,,Water,S,,N,$50.00,,50.00,,1.00,
+,,,,,,New Bank,S,,N,,-$50.00,,-50.00,,1.00

--- a/helpers.R
+++ b/helpers.R
@@ -45,7 +45,8 @@ loadAccount <- function( filename = '' ,
                                     AccountName == 'Phone' |
                                     AccountName == 'Gas' |
                                     AccountName == 'Internet' |
-                                    AccountName == 'Insurance' ,
+                                    AccountName == 'Insurance' |
+                                    AccountName == 'Rent' ,
                                    yes = 'Nut' ,
                                    ## OR together the list of accounts that you
                                    ## consider to be 'One Time' expenses (things
@@ -75,15 +76,15 @@ loadAccount <- function( filename = '' ,
 loadExpenses <- function( the_year ){
     ## CHANGEME:  for every year that you added to the ui.R selectInput field,
     ##            you need to add an expenses file to load here
-    if( the_year == "2015" ){
-        expenses <- loadAccount( filename = 'data/sample_2015_expenses.csv' , type = 'expenses' )
-    } else if( the_year == "2016" ){
+    if( the_year == "1995" ){
+        expenses <- loadAccount( filename = 'data/sample_expenses_1995.csv' , type = 'expenses' )
+    } else if( the_year == "1996" ){
         ## You can combine two (or more) files into a single year like so:
-        expenses <- loadAccount( filename = 'data/sample_2016H1_expenses.csv' , type = 'expenses' ) %>%
-            bind_rows( loadAccount( filename = 'data/sample_2016H2_expenses.csv' , type = 'expenses' ) )
-    } else if( the_year == "2017" ){
+        expenses <- loadAccount( filename = 'data/sample_expenses_1996H1.csv' , type = 'expenses' ) %>%
+            bind_rows( loadAccount( filename = 'data/sample_expenses_1996H2.csv' , type = 'expenses' ) )
+    } else if( the_year == "1997" ){
         ## Keep the latest year's expenses up to date with regular exports
-        expenses <- loadAccount( filename = 'data/sample_2017_expenses_ytd.csv' , type = 'expenses' )
+        expenses <- loadAccount( filename = 'data/sample_expenses_1997_ytd.csv' , type = 'expenses' )
     }
     return( expenses )
 }

--- a/ui.R
+++ b/ui.R
@@ -16,13 +16,13 @@ shinyUI(
                                ##            exports for?
                                label = "Fiscal Year",
                                ## TODO: autofill these years
-                               choices = c( "2015" ,
-                                           "2016" ,
-                                           "2017" ),
+                               choices = c( "1995" ,
+                                           "1996" ,
+                                           "1997" ),
                                ## TODO:  auto select most recent data
                                ## CHANGEME:  what do you want the default year
                                ##            to be?
-                               selected = "2017" )
+                               selected = "1997" )
                    ),
             column(4,
                    "" )


### PR DESCRIPTION
I found regular sample data in the gnucash github repo:

https://github.com/Gnucash/gnucash/tree/master/doc/examples

I initially loaded reg_doc_example.gnucash and then imported
ms-money.qif. Some of the categories of interest were missing
or put under the wrong parent category so I manually tweaked
the new output file.

I then changed the default in the helpers.R loading function
and the years displayed in ui.R to match the new sampled data.